### PR TITLE
Add detail properties for better customized form

### DIFF
--- a/app/js/models/schemaModel.js
+++ b/app/js/models/schemaModel.js
@@ -763,6 +763,7 @@ export default class SchemaModel extends Model {
         const enumValues = [];
         const options = {};
         const headers = {};
+        const properties = [];
 
         headers['X-Auth-Token'] = this.collection.userModel.authToken();
         const relatedSchema = this.collection.get(schema.relation);
@@ -773,10 +774,12 @@ export default class SchemaModel extends Model {
               for (let value of data[key]) {
                 enumValues.push(value.id);
                 options[value.id] = value.name;
+                properties.push(value);
               }
             }
             schema.enum = enumValues;
             schema.options = options;
+            schema.properties = properties;
             resolve(schema);
           }, error => {
             reject(error);

--- a/app/js/views/dialogView.js
+++ b/app/js/views/dialogView.js
@@ -53,7 +53,7 @@ export default class DialogView extends View {
           'max-height': $(window).height() - 200 + 'px',
           'overflow-y': 'auto'
         });
-        $('#name').focus();
+        this.form.focus();
       },
       onhide: this.onhide,
       onshow: this.onshow

--- a/test/models/schemaModel.js
+++ b/test/models/schemaModel.js
@@ -458,6 +458,12 @@ describe('SchemaModel ', () => {
               options: {
                 sampleIdFoo: 'sample_name_bar'
               },
+              properties: [
+                {
+                  id: 'sampleIdFoo',
+                  name: 'sample_name_bar'
+                }
+              ],
               relation: 'sampleParent'
             }
           },


### PR DESCRIPTION
Add detailed properties for relation schema object. This helps to generate customized form purpose. Also, changes the way of focusing the first form element to use backbone form method.