### PR TITLE
Fix Popover Parse Bug

### DIFF
--- a/app/js/views/tableView.js
+++ b/app/js/views/tableView.js
@@ -336,7 +336,7 @@ export default class TableView extends View {
       if (property.type.includes('object') || (property.originalType && property.originalType.includes('object'))) {
         content = $('<pre style="width:500px;"></pre>').text(
           '<pre>' + jsyaml.safeDump(value) + '</pre>').html();
-        content = content.replace('\'', '&#34;');
+        content = content.replace(/\'/g, '&#39;');
         return dataPopupTemplate({
           content
         });


### PR DESCRIPTION
Fixes the bug that it can't parse correctly in some case. Also, change from `"` to `'` for string format for consistency with detail view.