### PR TITLE
Fix skipping manual id input

### DIFF
--- a/app/js/models/schemaModel.js
+++ b/app/js/models/schemaModel.js
@@ -1036,9 +1036,6 @@ export default class SchemaModel extends Model {
     if (schema.properties !== undefined) {
       const result = {};
       for (let key in schema.properties) {
-        if (key === 'id') {
-          continue;
-        }
         result[key] = self.toServerData(schema.properties[key], data[key]);
       }
       return result;

--- a/test/models/schemaModel.js
+++ b/test/models/schemaModel.js
@@ -783,6 +783,7 @@ describe('SchemaModel ', () => {
       };
 
       model.toServerData(schema, data).should.be.deep.equal({
+        id: '123321123321',
         name: 'foo'
       });
     });


### PR DESCRIPTION
Id can be defined by user manually, is doesn't need to skip.