### PR TITLE
Apply Edtor form to text format

### DIFF
--- a/app/css/less/variables.less
+++ b/app/css/less/variables.less
@@ -838,7 +838,7 @@
 
 @pre-bg:                      #f5f5f5;
 @pre-color:                   @gray-dark;
-@pre-border-color:            #ccc;
+@pre-border-color:            #eee;
 @pre-scrollable-max-height:   340px;
 
 

--- a/app/js/models/schemaModel.js
+++ b/app/js/models/schemaModel.js
@@ -731,7 +731,7 @@ export default class SchemaModel extends Model {
             schema[key].options = value.enum;
           }
         } else if (value.format !== undefined &&
-          (value.format === 'yaml' || value.format === 'javascript')) {
+          (value.format === 'yaml' || value.format === 'javascript' || value.format === 'text')) {
           schema[key].format = value.format;
           schema[key].type = 'CodeEditor';
         } else {
@@ -761,7 +761,7 @@ export default class SchemaModel extends Model {
               schema[key].options = value.items.enum;
             }
           } else if (value.format !== undefined &&
-            (value.format === 'yaml' || value.format === 'javascript')) {
+            (value.format === 'yaml' || value.format === 'javascript' || value.format === 'text')) {
             schema[key].format = value.format;
             schema[key].itemType = 'CodeEditor';
           } else {
@@ -779,7 +779,7 @@ export default class SchemaModel extends Model {
       } else if (value.type === 'boolean') {
         schema[key].type = 'Checkbox';
       }
-      if (value.format !== undefined) {
+      if (value.format !== undefined && value.format !== 'text') {
         schema[key].validators.push(value.format);
       }
       if (json.required !== undefined &&

--- a/app/js/views/detailView.js
+++ b/app/js/views/detailView.js
@@ -146,7 +146,7 @@ export default class DetailView extends View {
     if (property.type === 'array') {
       return '<pre>' + jsyaml.safeDump(value) + '</pre>';
     }
-    if (property.type === 'string' && property.format === 'yaml') {
+    if (property.type === 'string' && (property.format === 'yaml' || property.format === 'text')) {
       return '<pre>' + _.escape(value) + '</pre>';
     }
     return _.escape(value);

--- a/app/js/views/tableView.js
+++ b/app/js/views/tableView.js
@@ -416,7 +416,13 @@ export default class TableView extends View {
     } catch (error) {
       console.error(error);
     }
-
+    if (property.type === 'string' && (property.format === 'yaml' || property.format === 'text')) {
+      content = _.escape(value);
+      content = value.replace(/\'/g, '&#39;');
+      return dataPopupTemplate({
+        content: '<pre>' + content + '</pre>'
+      });
+    }
     return _.escape(value);
   }
 


### PR DESCRIPTION
This is a temporally solution to use code editor for some properties which might be suitable to use code editor for edit. Since gohan allows to use 'text' format for string type, this commit apply code editor for text format. The 'text' format was used for converting to '<textarea>' as JSON form (previous library) spec. That's why gohan allows to use 'text' format.
