### PR TITLE
Fix CustomAction Error Message

### DIFF
--- a/app/js/models/customActionModel.js
+++ b/app/js/models/customActionModel.js
@@ -48,8 +48,10 @@ export default class CustomActionModel extends Model {
         if (response.ok) {
           response.text().then(data => resolve(data)).catch(error => reject(error));
         } else {
-          reject(response.statusText);
-          console.error(response.statusText);
+          response.json().then(data => {
+            reject(data.error);
+            console.error(data.error);
+          });
         }
       }).catch(error => {
         reject(error);


### PR DESCRIPTION
Currently, CustomAction Error Message shows only "Bad Request" which is not user-friendly. This commits fixes to show the detail error message so that user can see the actual error.