### PR TITLE
Set display none for cross icon in dialog validation error toast.

### DIFF
--- a/css/sass/dialog.scss
+++ b/css/sass/dialog.scss
@@ -25,6 +25,10 @@ $object-field-background: #ebf1f5;
     padding: 20px;
     font-size: 0.875rem;
     color: #333;
+
+    .pt-toast.pt-intent-danger .pt-icon-cross {
+      display: none;
+    }
   }
   .pt-dialog-footer {
     box-shadow: 0 -1px 0 rgba(16, 22, 26, 0.15);


### PR DESCRIPTION
ESI-15932

It's a temporary solution because there is no easy way to manage toaster visibility (ErrorListTemplate doesn't have updated errors list on field value change).