### PR TITLE
Fixed displaying and editing text in CodeWidget.

### DIFF
--- a/css/form.scss
+++ b/css/form.scss
@@ -189,6 +189,10 @@
   .CodeMirror {
     font-size: 0.875rem;
     height: 16rem;
+
+    &-scroll {
+      max-width: 850px;
+    }
   }
 }
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -330,10 +330,6 @@ table.gohan-table {
   }
 }
 
-.pt-dialog .CodeMirror pre span {
-  padding-left: 20px;
-}
-
 .gohan-table-header {
   margin-bottom: 1rem;
   padding-left: 0;

--- a/src/Dialog/formComponents/widgets/CodeWidget.jsx
+++ b/src/Dialog/formComponents/widgets/CodeWidget.jsx
@@ -1,26 +1,52 @@
-import React from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import CodeMirror from 'react-codemirror';
+import jsyaml from 'js-yaml';
 import 'codemirror/mode/yaml/yaml';
 import 'codemirror/mode/javascript/javascript';
 
-function CodeWidget(props) {
-  const {readonly, value, onChange} = props;
-  const {format} = props.schema;
+class CodeWidget extends Component {
+  componentDidMount() {
+    setTimeout(() => {
+      this.editor.getCodeMirror().refresh();
+    }, 200);
+  }
 
-  return <CodeMirror value={value}
-    onChange={onChange}
-    options={{
-      mode: format,
-      lineNumbers: true,
-      theme: 'material',
-      readonly
-    }}
-  />;
+  render() {
+    const {
+      readonly,
+      value,
+      onChange,
+      schema
+    } = this.props;
+    const {format} = schema;
+
+    return (
+      <CodeMirror onChange={onChange}
+        value={format === 'yaml' ? jsyaml.safeDump(value) : value}
+        ref={editor => {this.editor = editor;}}
+        options={{
+          mode: format,
+          lineNumbers: true,
+          theme: 'material',
+          readonly
+        }}
+      />
+    );
+  }
 }
+
+CodeWidget.defaultProps = {
+  value: '',
+  readonly: true,
+};
+
 if (process.env.NODE_ENV !== 'production') {
   CodeWidget.propTypes = {
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]),
     readonly: PropTypes.bool,
     schema: PropTypes.object.isRequired
   };


### PR DESCRIPTION
ESI-16746
This fix is kinda hack but solution suggested in [this issue](https://github.com/JedWatson/react-codemirror/issues/6) doesn't work without using `setTimeout`.

Fixed issues:
- Text is hidden behind line numbers label
![gutter_line_numbers](https://user-images.githubusercontent.com/28134389/35435863-8e399624-028c-11e8-802d-dac8034be229.gif)
- Broken horizontal scroll
![scroll](https://user-images.githubusercontent.com/28134389/35435880-a072ee62-028c-11e8-875e-92aa3efd6ce4.gif)
- Jumping cursor
![jumping_cursor](https://user-images.githubusercontent.com/28134389/35435914-bc94354c-028c-11e8-962e-5a7d96becfcd.gif)

