### PR TITLE
Changed value of empty dialog text input from undefined to empty string.

### DIFF
--- a/src/Dialog/formComponents/widgets/BaseInput.js
+++ b/src/Dialog/formComponents/widgets/BaseInput.js
@@ -17,7 +17,7 @@ class BaseInput extends Component {
   }
 
   onInputChange = event => {
-    const value = (event.target.value === '' && this.props.required) ? undefined : event.target.value;
+    const value = event.target.value;
     const errors = [];
 
     if (this.props.required && !value) {

--- a/src/Dialog/utils.js
+++ b/src/Dialog/utils.js
@@ -7,7 +7,7 @@ export const toServerData = (schema, data) => {
     return null;
   }
 
-  if (data === undefined || data === null || data === '') {
+  if (data === undefined || data === null) {
     return undefined;
   }
 


### PR DESCRIPTION
UIE-175

Note:
Backed doesn't validate required fields while they are an empty string so user can set required field like a name to empty string.