### PR TITLE
Fixed setting initial state in ArrayField. [CW-790]

### DIFF
--- a/src/Dialog/formComponents/fields/ArrayField/ArrayField.js
+++ b/src/Dialog/formComponents/fields/ArrayField/ArrayField.js
@@ -76,7 +76,7 @@ export default class ArrayField extends Component {
         itemSchema = schema.additionalItems;
       }
 
-      if (isEmpty(this.props.formData) && this.props.required) {
+      if (isEmpty(items) && this.props.required) {
         this.props.onChange(items.concat([
           getDefaultFormState(itemSchema, undefined, definitions)
         ]), {validate: false});

--- a/src/Dialog/formComponents/fields/ArrayField/ArrayField.test.js
+++ b/src/Dialog/formComponents/fields/ArrayField/ArrayField.test.js
@@ -2,11 +2,14 @@
 import React from 'react';
 import chai from 'chai';
 import chaiEnzyme from 'chai-enzyme';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 import ArrayField from './ArrayField';
 
 chai.use(chaiEnzyme());
+chai.use(sinonChai);
 chai.should();
 
 describe('< ArrayField />', () => {
@@ -25,5 +28,79 @@ describe('< ArrayField />', () => {
     );
 
     wrapper.should.not.equal(undefined);
+  });
+
+  it('should call onChange with appropriate items on componentDidMount', () => {
+    const onChange = sinon.spy();
+    const wrapper = mount( // eslint-disable-line
+      <ArrayField onChange={onChange}
+        required={true}
+        schema={{
+          default: [],
+          items: {
+            properties: {
+              name: {
+                type: 'string'
+              }
+            },
+            type: 'object',
+          },
+          type: 'array',
+        }}
+      />
+    );
+
+    onChange.should.callCount(1);
+    onChange.should.have.been.calledWith([{name: undefined}], {validate: false});
+  });
+
+  it('should not call onChange on componentDidMount when field isn\'t required', () => {
+    const onChange = sinon.spy();
+    mount( // eslint-disable-line
+      <ArrayField onChange={onChange}
+        schema={{
+          default: [],
+          items: {
+            properties: {
+              name: {
+                type: 'string'
+              }
+            },
+            type: 'object',
+          },
+          type: 'array',
+        }}
+      />
+    );
+
+    onChange.should.callCount(0);
+  });
+
+  it('should not call onChange when field has data before componentDidMount', () => {
+    const onChange = sinon.spy();
+    mount( // eslint-disable-line
+      <ArrayField onChange={onChange}
+        required={true}
+        schema={{
+          minItems: 1,
+          items: {
+            properties: {
+              ranges: {
+                minItems: 1,
+                items: {
+                  type: 'string',
+                },
+                type: 'array'
+              }
+            },
+            required: ['ranges'],
+            type: 'object',
+          },
+          type: 'array',
+        }}
+      />
+    );
+
+    onChange.should.callCount(0);
   });
 });


### PR DESCRIPTION
#### What has changed in the code ####

I've changed data passed to `isEmpty` in `componentDidMount`, `if` statement.

#### Reasons for making this change ####

Data (directly from props) passed to the `isEmpty` in `componentDidMount` was outdated, because in `constructor`, `getStateFromProps` was used to set appropriate initial state.

### Checklist

* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've added unit test for feature
  - [ ] I've ran lint

![screenshot from 2018-10-10 08-39-57](https://user-images.githubusercontent.com/28134389/46717423-35700900-cc68-11e8-8529-c95210590699.png)

