### PR TITLE
Fixed displaying ids instead of names in MultiSelect. CW-947

### DIFF
--- a/src/Dialog/formComponents/fields/ArrayField/ArrayField.js
+++ b/src/Dialog/formComponents/fields/ArrayField/ArrayField.js
@@ -10,6 +10,8 @@ import Tab from './../../../../components/Tabs/Tab';
 import Tabs from './../../../../components/Tabs/Tabs';
 import {ArraySortableItem} from './ArraySortableItem';
 
+import {optionsListObject} from '../../utils';
+
 import {
   getUiOptions,
   getWidget,
@@ -430,7 +432,10 @@ export default class ArrayField extends Component {
     const {items} = this.state;
     const {widgets, definitions} = this.props.registry;
     const itemsSchema = retrieveSchema(schema.items, definitions);
-    const enumOptions = optionsList(itemsSchema);
+    const enumOptions = (itemsSchema && itemsSchema.options) ?
+      optionsListObject(itemsSchema) :
+      optionsList(itemsSchema);
+
     const {
       widget = 'select',
       ...options


### PR DESCRIPTION
CW-947

![screenshot from 2018-12-12 17-57-33](https://user-images.githubusercontent.com/28134389/49885955-d3cf4500-fe38-11e8-8607-a52c8dd566fe.png)


#### What has changed in the code ####

Changed method used for creating `enumOptions` for MultiSelect when items schema has realtion.

#### Reasons for making this change ####
    
MultiSelect displayed ids instead of names in options.

### Checklist

* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've added unit test for feature
  - [X] I've ran lint
