### PR TITLE
Disabled closing dialog on click outside of the dialog window.

### DIFF
--- a/src/Dialog/Dialog.jsx
+++ b/src/Dialog/Dialog.jsx
@@ -99,6 +99,7 @@ export class GeneratedDialog extends Component {
     return (
       <Dialog title={title}
         enforceFocus={false}
+        canOutsideClickClose={false}
         {...this.props}>
         <div className="pt-dialog-body">
           <ErrorToast />


### PR DESCRIPTION
#### What has changed in the code ####

Changed `canOutsideClickClose` prop to disable closing dialog when a user clicks outside of the dialog window.

#### Reasons for making this change ####

It's irritating during filling out the form, when the user is in the middle of the process and clicks outside of the dialog window. In this case, all changes are lost.

### Checklist

* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've added unit test for feature
  - [X] I've ran lint
