### PR TITLE
Added support of is_public and any_of.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .sass-cache
 coverage
 doc/
+.idea/

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -8,11 +8,13 @@ import {
   getSchema,
   getCollectionUrl,
   getSingularUrl,
-  hasSchemaProperty
+  hasSchemaProperty,
+  getIsPublicExists
 } from './../schema/SchemaSelectors';
 import {
   isTenantFilterActive,
-  getTenantId
+  getTenantId,
+  getTenantFilterUseAnyOf
 } from './../auth/AuthSelectors';
 import {getGohanUrl} from './../config/ConfigSelectors';
 import {getPageLimit, getPollingInterval, isPolling} from '../config/ConfigSelectors';
@@ -35,14 +37,19 @@ export class GetCollectionObservable extends AjaxObservable {
       'Content-Type': 'application/json',
       'X-Auth-Token': getTokenId(state)
     };
+    const anyOf = getTenantFilterUseAnyOf(state);
+    const isPublic = getIsPublicExists(state, schemaId);
+    const isTenantFilterOn = isTenantFilterActive(state);
 
     super({
       method: 'GET',
       url: `${gohanUrl}${url}?${queryStringify({
         limit: defaultPageLimit,
-        tenant_id: isTenantFilterActive(state) && // eslint-disable-line camelcase
+        tenant_id: isTenantFilterOn && // eslint-disable-line camelcase
           hasSchemaProperty(state, schemaId, 'tenant_id') ?
           getTenantId(state) : undefined,
+        is_public: isTenantFilterOn && isPublic ? isPublic : undefined, // eslint-disable-line camelcase
+        any_of: isTenantFilterOn && isPublic ? anyOf : undefined, // eslint-disable-line camelcase
         ...query
       })}`,
       headers,

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -83,7 +83,10 @@ describe('API', () => {
           {
             id: 'food',
             prefix: '/v1.0',
-            plural: 'foods'
+            plural: 'foods',
+            schema: {
+              properties: {}
+            }
           }
         ]
       },

--- a/src/auth/AuthActions.js
+++ b/src/auth/AuthActions.js
@@ -29,8 +29,10 @@ export const loginSuccess = (
   tokenExpires,
   user,
   prefix,
+  tenantFilterUseAnyOf
 ) => {
   sessionStorage.setItem(`${prefix}UnscopedToken`, tokenId);
+  sessionStorage.setItem(`${prefix}TenantFilterUseAnyOf`, tenantFilterUseAnyOf);
 
   return {
     type: LOGIN_SUCCESS,
@@ -38,6 +40,7 @@ export const loginSuccess = (
       tokenId,
       tokenExpires,
       user,
+      tenantFilterUseAnyOf
     },
   };
 };
@@ -66,8 +69,10 @@ export const scopedLoginSuccess = (
   scope,
   prefix,
   logoutTimeoutId,
+  tenantFilterUseAnyOf
 ) => {
   sessionStorage.setItem(`${prefix}ScopedToken`, tokenId);
+  sessionStorage.setItem(`${prefix}TenantFilterUseAnyOf`, tenantFilterUseAnyOf);
 
   return {
     type: SCOPED_LOGIN_SUCCESS,
@@ -76,7 +81,8 @@ export const scopedLoginSuccess = (
       tokenExpires,
       roles,
       scope,
-      logoutTimeoutId
+      logoutTimeoutId,
+      tenantFilterUseAnyOf
     },
   };
 };
@@ -113,6 +119,7 @@ export const fetchTokenData = prefix => {
   const tenantId = sessionStorage.getItem(`${prefix}TenantId`);
   const tenantName = sessionStorage.getItem(`${prefix}TenantName`);
   const tenantFilterStatus = sessionStorage.getItem(`${prefix}TenantFilterStatus`);
+  const tenantFilterUseAnyOf = sessionStorage.getItem(`${prefix}TenantFilterUseAnyOf`);
 
   const tenant = (tenantId && tenantName) ?
     {id: tenantId, name: tenantName} :
@@ -125,6 +132,7 @@ export const fetchTokenData = prefix => {
       unscopedToken,
       tenant,
       tenantFilterStatus: tenantFilterStatus === 'true',
+      tenantFilterUseAnyOf: tenantFilterUseAnyOf === 'true'
     };
   }
 
@@ -142,10 +150,12 @@ export const checkTokenSuccess = (
   tenantFilterStatus,
   prefix,
   logoutTimeoutId,
+  tenantFilterUseAnyOf
 ) => {
   sessionStorage.setItem(`${prefix}ScopedToken`, tokenId);
   sessionStorage.setItem(`${prefix}UnscopedToken`, unscopedToken);
   sessionStorage.setItem(`${prefix}TenantFilterStatus`, tenantFilterStatus);
+  sessionStorage.setItem(`${prefix}TenantFilterUseAnyOf`, tenantFilterUseAnyOf);
 
   return {
     type: CHECK_SUCCESS,
@@ -158,7 +168,8 @@ export const checkTokenSuccess = (
       roles,
       scope,
       tenantFilterStatus,
-      logoutTimeoutId
+      logoutTimeoutId,
+      tenantFilterUseAnyOf
     },
   };
 };
@@ -169,6 +180,7 @@ export const clearStorage = prefix => {
   sessionStorage.removeItem(`${prefix}TenantId`);
   sessionStorage.removeItem(`${prefix}TenantName`);
   sessionStorage.removeItem(`${prefix}TenantFilterStatus`);
+  sessionStorage.removeItem(`${prefix}TenantFilterUseAnyOf`);
 
   return {
     type: CLEAR_STORAGE

--- a/src/auth/AuthActions.test.js
+++ b/src/auth/AuthActions.test.js
@@ -19,21 +19,44 @@ describe('AuthActions ', () => {
   });
 
   describe('loginSuccess()', () => {
-    it(`should set unscoped token in session storage and returns ${actionTypes.LOGIN_SUCCESS} action`, () => {
+    it(`should set unscoped token in session storage and returns ${actionTypes.LOGIN_SUCCESS} action, anyOf on`, () => {
       actions.loginSuccess(
         'tokenId',
         '1/2/2017',
         {name: 'user'},
-        'prefix'
+        'prefix',
+        true
       ).should.deep.equal({
         type: actionTypes.LOGIN_SUCCESS,
         data: {
           tokenId: 'tokenId',
           tokenExpires: '1/2/2017',
           user: {name: 'user'},
+          tenantFilterUseAnyOf: true
         }
       });
       sessionStorage['prefixUnscopedToken'].should.equal('tokenId');
+      sessionStorage['prefixTenantFilterUseAnyOf'].should.equal('true');
+    });
+
+    it(`should set unscoped token in session storage and returns ${actionTypes.LOGIN_SUCCESS} action,anyOf off`, () => {
+      actions.loginSuccess(
+        'tokenId',
+        '1/2/2017',
+        {name: 'user'},
+        'prefix',
+        false
+      ).should.deep.equal({
+        type: actionTypes.LOGIN_SUCCESS,
+        data: {
+          tokenId: 'tokenId',
+          tokenExpires: '1/2/2017',
+          user: {name: 'user'},
+          tenantFilterUseAnyOf: false
+        }
+      });
+      sessionStorage['prefixUnscopedToken'].should.equal('tokenId');
+      sessionStorage['prefixTenantFilterUseAnyOf'].should.equal('false');
     });
   });
 
@@ -72,6 +95,7 @@ describe('AuthActions ', () => {
         },
         'prefix',
         123,
+        true
       ).should.deep.equal({
         type: actionTypes.SCOPED_LOGIN_SUCCESS,
         data: {
@@ -87,10 +111,12 @@ describe('AuthActions ', () => {
             }
           },
           logoutTimeoutId: 123,
+          tenantFilterUseAnyOf: true
         }
       });
 
       sessionStorage['prefixScopedToken'].should.equal('fooToken');
+      sessionStorage['prefixTenantFilterUseAnyOf'].should.equal('true');
     });
   });
 
@@ -164,6 +190,7 @@ describe('AuthActions ', () => {
       sessionStorage.setItem('prefixTenantId', 'tenantId');
       sessionStorage.setItem('prefixTenantName', 'tenantName');
       sessionStorage.setItem('prefixTenantFilterStatus', 'false');
+      sessionStorage.setItem('prefixTenantFilterUseAnyOf', 'true');
 
       actions.fetchTokenData('prefix').should.deep.equal({
         type: actionTypes.CHECK_TOKEN,
@@ -174,6 +201,7 @@ describe('AuthActions ', () => {
           name: 'tenantName',
         },
         tenantFilterStatus: false,
+        tenantFilterUseAnyOf: true
       });
     });
   });
@@ -392,6 +420,7 @@ describe('AuthActions ', () => {
         false,
         'prefix',
         123,
+        true
       ));
       store.getActions().should.deep.equal([
         {
@@ -410,6 +439,7 @@ describe('AuthActions ', () => {
               }
             },
             tenantFilterStatus: false,
+            tenantFilterUseAnyOf: true
           }
         }
       ]);

--- a/src/auth/AuthEpics.test.js
+++ b/src/auth/AuthEpics.test.js
@@ -90,7 +90,8 @@ describe('AuthEpics', () => {
                     id: '423f19a4ac1e4f48bbb4180756e6eb6c',
                     name: 'admin',
                     password_expires_at: null // eslint-disable-line camelcase
-                  }
+                  },
+                  tenantFilterUseAnyOf: true
                 }
               },
               b: {
@@ -164,6 +165,7 @@ describe('AuthEpics', () => {
                 data: {
                   tokenExpires: '2015-11-06T15:32:17.893769Z',
                   tokenId: 'subjectTokenId',
+                  tenantFilterUseAnyOf: false,
                   user: {
                     domain: {
                       id: 'foo',
@@ -171,7 +173,7 @@ describe('AuthEpics', () => {
                     },
                     id: '423f19a4ac1e4f48bbb4180756e6eb6c',
                     name: 'Bar',
-                    password_expires_at: null // eslint-disable-line camelcase
+                    password_expires_at: null // eslint-disable-line camelcase,
                   }
                 }
               },
@@ -243,6 +245,7 @@ describe('AuthEpics', () => {
                 data: {
                   tokenExpires: '2015-11-06T15:32:17.893769Z',
                   tokenId: 'subjectTokenId',
+                  tenantFilterUseAnyOf: false,
                   user: {
                     domain: {
                       id: 'default',
@@ -338,6 +341,7 @@ describe('AuthEpics', () => {
                 data: {
                   tokenExpires: '2015-11-06T15:32:17.893769Z',
                   tokenId: 'subjectTokenId',
+                  tenantFilterUseAnyOf: false,
                   user: {
                     domain: {
                       id: 'configDomainId',
@@ -496,6 +500,7 @@ describe('AuthEpics', () => {
                 data: {
                   tokenId: 'subjectTokenId',
                   tokenExpires: '2018-12-23T20:20:31.000000Z',
+                  tenantFilterUseAnyOf: true,
                   logoutTimeoutId: 123,
                   roles: [
                     {name: 'admin'},
@@ -571,6 +576,7 @@ describe('AuthEpics', () => {
                   logoutTimeoutId: 123,
                   tokenId: 'subjectTokenId',
                   tokenExpires: '2018-12-23T20:20:31.000000Z',
+                  tenantFilterUseAnyOf: true,
                   roles: [
                     {name: 'admin'},
                   ],

--- a/src/auth/AuthSelectors.js
+++ b/src/auth/AuthSelectors.js
@@ -13,6 +13,7 @@ const showTokenRenewal = state => state.authReducer.showTokenRenewal;
 const tenantFilterStatus = state => state.authReducer.tenantFilterStatus;
 const roles = state => state.authReducer.roles || [];
 const domains = state => state.authReducer.domains || [];
+const tenantFilterUseAnyOf = state => state.authReducer.tenantFilterUseAnyOf;
 
 export const getLoggedState = createSelector(
   [isLogged],
@@ -134,4 +135,9 @@ export const getTenantsByDomain = createSelector(
       return result;
     }, {});
   }
+);
+
+export const getTenantFilterUseAnyOf = createSelector(
+  [tenantFilterUseAnyOf],
+  tenantFilterUseAnyOf => tenantFilterUseAnyOf
 );

--- a/src/auth/authReducer.js
+++ b/src/auth/authReducer.js
@@ -28,7 +28,8 @@ export default function authReducer(state = {
   domains: [],
   roles: [],
   scope: {},
-  logoutTimeoutId: -1
+  logoutTimeoutId: -1,
+  tenantFilterUseAnyOf: false
 }, action) {
   switch (action.type) {
     case CLEAR_STORAGE:
@@ -36,7 +37,8 @@ export default function authReducer(state = {
         inProgress: false,
         logged: false,
         showTokenRenewal: false,
-        tenantFilterStatus: false
+        tenantFilterStatus: false,
+        tenantFilterUseAnyOf: false
       };
     case LOGOUT:
       return {
@@ -45,6 +47,7 @@ export default function authReducer(state = {
         showTokenRenewal: false,
         tenantFilterStatus: false,
         logoutTimeoutId: -1,
+        tenantFilterUseAnyOf: false
       };
     case LOGIN_INPROGRESS:
       return {
@@ -60,7 +63,8 @@ export default function authReducer(state = {
         unscopedToken: action.data.tokenId,
         user: action.data.user,
         inProgress: false,
-        showTokenRenewal: false
+        showTokenRenewal: false,
+        tenantFilterUseAnyOf: action.data.tenantFilterUseAnyOf
       };
     case SCOPED_LOGIN:
       return {
@@ -76,7 +80,8 @@ export default function authReducer(state = {
         scope: action.data.scope,
         inProgress: false,
         showTokenRenewal: false,
-        logoutTimeoutId: action.data.logoutTimeoutId
+        logoutTimeoutId: action.data.logoutTimeoutId,
+        tenantFilterUseAnyOf: action.data.tenantFilterUseAnyOf
       };
     case SCOPED_LOGIN_ERROR:
       return {
@@ -100,6 +105,7 @@ export default function authReducer(state = {
         showTokenRenewal: false,
         tenantFilterStatus: action.data.tenantFilterStatus,
         logged: true,
+        tenantFilterUseAnyOf: action.data.tenantFilterUseAnyOf
       };
     case SELECT_TENANT:
       return {

--- a/src/auth/authReducer.test.js
+++ b/src/auth/authReducer.test.js
@@ -18,6 +18,7 @@ describe('authReducer ', () => {
         domains: [],
         roles: [],
         scope: {},
+        tenantFilterUseAnyOf: false
       });
     reducer({}, {}).should.deep.equal({});
   });
@@ -31,6 +32,7 @@ describe('authReducer ', () => {
         user: {
           username: 'Admin'
         },
+        tenantFilterUseAnyOf: true
       }
     }).should.deep.equal(
       {
@@ -47,6 +49,7 @@ describe('authReducer ', () => {
         domains: [],
         roles: [],
         scope: {},
+        tenantFilterUseAnyOf: true
       }
     );
   });
@@ -63,6 +66,7 @@ describe('authReducer ', () => {
       domains: [],
       roles: [],
       scope: {},
+      tenantFilterUseAnyOf: false
     });
   });
 
@@ -74,7 +78,8 @@ describe('authReducer ', () => {
       inProgress: false,
       logged: false,
       logoutTimeoutId: -1,
-      showTokenRenewal: false
+      showTokenRenewal: false,
+      tenantFilterUseAnyOf: false
     });
   });
 
@@ -90,6 +95,7 @@ describe('authReducer ', () => {
       domains: [],
       roles: [],
       scope: {},
+      tenantFilterUseAnyOf: false
     });
   });
 
@@ -116,6 +122,7 @@ describe('authReducer ', () => {
       domains: [],
       roles: [],
       scope: {},
+      tenantFilterUseAnyOf: false
     });
   });
 
@@ -135,8 +142,8 @@ describe('authReducer ', () => {
       inProgress: false,
       logged: false,
       showTokenRenewal: false,
-      tenantFilterStatus: false
-
+      tenantFilterStatus: false,
+      tenantFilterUseAnyOf: false
     });
   });
 });

--- a/src/schema/SchemaSelectors.js
+++ b/src/schema/SchemaSelectors.js
@@ -190,3 +190,8 @@ export const getCollectionActions = createSelector(
     return result;
   }, {})
 );
+
+export const getIsPublicExists = createSelector(
+  [schema],
+  schema => schema.schema.properties.is_public !== undefined
+);

--- a/src/schema/SchemaSelectors.test.js
+++ b/src/schema/SchemaSelectors.test.js
@@ -585,4 +585,35 @@ describe('SchemaSelectors', () => {
       });
     });
   });
+
+  describe('getIsPublicExists()', () => {
+    const schema = {
+      schemaReducer: {
+        data: [
+          {
+            id: 'foo',
+            schema: {
+              properties: {
+                is_public: {} // eslint-disable-line camelcase
+              }
+            }
+          },
+          {
+            id: 'bar',
+            schema: {
+              properties: {}
+            }
+          }
+        ]
+      }
+    };
+
+    it('should return true when is_public exists', () => {
+      selectors.getIsPublicExists(schema, 'foo').should.equal(true);
+    });
+
+    it('should return false when is_public does not exist', () => {
+      selectors.getIsPublicExists(schema, 'bar').should.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
#### What has changed in the code ####

When tenant filtering is active for some admin users and the schema has `is_public` property, the `any_of` parameter is added to query. These admin users are able to see public resources.

#### Reasons for making this change ####
    
Some admins should see public resources when tenant filtering is on.

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [x] I've added unit test for feature
  - [x] I've ran lint
