### PR TITLE
Add possibility to pass props to open dialog.

### DIFF
--- a/src/Dialog/DialogAction.test.js
+++ b/src/Dialog/DialogAction.test.js
@@ -747,12 +747,13 @@ describe('DialogActions ', () => {
       const storeObject = {};
       const store = mockStore(storeObject);
 
-      store.dispatch(actions.openDialog('foo')());
+      store.dispatch(actions.openDialog('foo')({id: 'sampleId'}));
 
       store.getActions().should.deep.equal([
         {
           type: actionTypes.OPEN,
           name: 'foo',
+          additionalProps: {id: 'sampleId'}
         }
       ]);
     });

--- a/src/Dialog/DialogActions.js
+++ b/src/Dialog/DialogActions.js
@@ -53,10 +53,11 @@ export function clearData() {
   };
 }
 
-export const openDialog = name => () => dispatch => dispatch(
+export const openDialog = name => additionalProps => dispatch => dispatch(
   {
     type: OPEN,
-    name
+    name,
+    additionalProps
   }
 );
 

--- a/src/Dialog/DialogSelectors.js
+++ b/src/Dialog/DialogSelectors.js
@@ -30,7 +30,11 @@ export const getSchema = createSelector(
 );
 
 export const isOpen = createSelector(
-  [dialog], dialog => Boolean(dialog)
+  [dialog], dialog => dialog ? dialog.show : false
+);
+
+export const getAdditionalProps = createSelector(
+  [dialog], dialog => dialog ? dialog.additionalProps : {}
 );
 
 export const getError = createSelector(

--- a/src/Dialog/DialogSelectors.test.js
+++ b/src/Dialog/DialogSelectors.test.js
@@ -50,12 +50,59 @@ describe('DialogSelectors', () => {
         {
           dialogReducer: {
             dialogs: {
-              foo: true
+              foo: {
+                show: true,
+                additionalProps: {id: 'sampleId'}
+              }
             }
           }
         },
         'foo'
       ).should.equal(true);
+    });
+
+    it('should return appropriate state of dialog, if is close', () => {
+      selectors.isOpen(
+        {
+          dialogReducer: {
+            dialogs: {
+              foo: {
+                show: false,
+                additionalProps: {id: 'sampleId'}
+              }
+            }
+          }
+        },
+        'foo'
+      ).should.equal(false);
+    });
+  });
+
+  describe('getAdditionalProps', () => {
+    it('should return empty object for hidden dialog', () => {
+      selectors.getAdditionalProps(
+        {
+          dialogReducer: {
+            dialogs: {}
+          }
+        }
+      ).should.deep.equal({});
+    });
+
+    it('should return appropriate additional props', () => {
+      selectors.getAdditionalProps(
+        {
+          dialogReducer: {
+            dialogs: {
+              foo: {
+                show: true,
+                additionalProps: {id: 'sampleId'}
+              }
+            }
+          }
+        },
+        'foo'
+      ).should.deep.equal({id: 'sampleId'});
     });
   });
 

--- a/src/Dialog/dialogReducer.js
+++ b/src/Dialog/dialogReducer.js
@@ -23,7 +23,10 @@ export default function dialogReducer(
       return {
         ...state,
         dialogs: {
-          [action.name]: true
+          [action.name]: {
+            show: true,
+            additionalProps: action.additionalProps
+          }
         },
       };
     case CLOSE:

--- a/src/Dialog/dialogReducer.test.js
+++ b/src/Dialog/dialogReducer.test.js
@@ -31,11 +31,12 @@ describe('dialogReducer ', () => {
     dialogReducer(
       undefined, {
         type: actionTypes.OPEN,
-        name: 'foo'
+        name: 'foo',
+        additionalProps: {id: 'sampleId'}
       }
     ).should.deep.equal({
       dialogs: {
-        foo: true,
+        foo: {show: true, additionalProps: {id: 'sampleId'}},
       },
       isLoading: true,
       errorMessage: '',

--- a/src/Dialog/index.jsx
+++ b/src/Dialog/index.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
-import {isOpen} from './DialogSelectors';
+import {isOpen, getAdditionalProps} from './DialogSelectors';
 
 const dialog = defaults => {
   const {
@@ -26,7 +26,8 @@ const dialog = defaults => {
 
     const mapStateToProps = state => (
       {
-        isOpen: isOpen(state, name)
+        isOpen: isOpen(state, name),
+        additionalProps: getAdditionalProps(state, name),
       }
     );
 


### PR DESCRIPTION
#### What has changed in the code ####
Modifited selectors, action and reducer

#### Reasons for making this change ####
Sometimes we need to pass props directly to opened dialog e.g. dialog data or id for editing resource.

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [x] I've added unit test for feature
  - [x] I've ran lint
