### PR TITLE
Fixed getSidebarItems for no sidebarChildResources.

### DIFF
--- a/src/app/components/Sidebar/SidebarSelectors.js
+++ b/src/app/components/Sidebar/SidebarSelectors.js
@@ -34,7 +34,7 @@ const sidebarFavorites = state => {
   return [];
 };
 
-const getSidebarItems = (sidebar, schemas, sidebarChildResources) => {
+const getSidebarItems = (sidebar, schemas, sidebarChildResources = []) => {
   const sidebarItems = {};
 
   if (schemas !== undefined && Array.isArray(schemas)) {


### PR DESCRIPTION
#### What has changed in the code ####

* Fixed `getSidebarItems` for no `sidebarChildResources`.

#### Reasons for making this change ####
    
* App crashes when `sidebarChildResources` are not defined in config.

### Checklist

* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've added unit test for feature
  - [X] I've ran lint
