### PR TITLE
Fixed setting substring search depending on configuration.

### DIFF
--- a/src/config/ConfigAction.test.js
+++ b/src/config/ConfigAction.test.js
@@ -43,7 +43,8 @@ describe('ConfigActions ', () => {
           authUrl: 'http://localhost:9091/v2.0',
           gohan: {
             url: 'http://localhost:9091'
-          }
+          },
+          substringSearchEnabled: true
         }
       }
     ]);
@@ -68,7 +69,8 @@ describe('ConfigActions ', () => {
           authUrl: 'http://192.168.1.11:9091/v2.0',
           gohan: {
             url: 'http://192.168.1.11:9091'
-          }
+          },
+          substringSearchEnabled: true
         }
       }
     ]);

--- a/src/config/ConfigActions.js
+++ b/src/config/ConfigActions.js
@@ -30,7 +30,9 @@ function fetchSuccess(data) {
     if (data.storagePrefix) {
       const substringSearchEnabled = JSON.parse(sessionStorage.getItem(`${data.storagePrefix}SubstringSearchEnabled`));
 
-      data.substringSearchEnabled = substringSearchEnabled === true ? substringSearchEnabled : false;
+      data.substringSearchEnabled = substringSearchEnabled === null ? true : substringSearchEnabled;
+    } else {
+      data.substringSearchEnabled = true;
     }
 
     dispatch({data, type: FETCH_SUCCESS});


### PR DESCRIPTION
UIE-552

#### What has changed in the code ####

- setting substring search enabled when `sessionStorage` is empty
- setting substring search enabled when no `storagePrefix`

#### Reasons for making this change ####
    
Bugfix

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've added unit test for feature
  - [x] I've ran lint
