### PR TITLE
UIE-556 Add option to trigger preperSchema action silently.

### DIFF
--- a/src/Form/FormActions.js
+++ b/src/Form/FormActions.js
@@ -30,14 +30,16 @@ export const prepareSchemaFailure = (formName, error) => {
   });
 };
 
-export const prepareSchema = (formName, schema, action, parentProperty, uiSchema = {}) => {
+export const prepareSchema = (formName, schema, action, parentProperty, uiSchema = {}, silent = false) => {
   return async (dispatch, getState) => {
     const state = getState();
 
-    dispatch({
-      type: PREPARE_SCHEMA_START,
-      formName
-    });
+    if (!silent) {
+      dispatch({
+        type: PREPARE_SCHEMA_START,
+        formName
+      });
+    }
 
     try {
       const resultSchema = await toLocalSchema(schema, state, parentProperty, uiSchema);

--- a/src/Form/FormActions.test.js
+++ b/src/Form/FormActions.test.js
@@ -79,6 +79,15 @@ describe('FormActions', () => {
       });
     });
 
+    it('shouldn\'t dispatch any action when silent param is true', () => {
+      const storeState = {};
+      const store = mockStore(storeState);
+
+      store.dispatch(actions.prepareSchema('formName', {}, 'create', undefined, {}, true));
+
+      store.getActions().should.deep.equal([]);
+    });
+
     it(`should dispatch ${actionTypes.PREPARE_SCHEMA_SUCCESS}`, async () => {
       const storeState = {
         formReducer: {},


### PR DESCRIPTION
#### What has changed in the code ####
Add option to trigger preperSchema silently because sometimes we don't need to show loading state.
#### Reasons for making this change ####
Issue. We don't need to show loading sometimes,

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've added unit test for feature
  - [x] I've ran lint
